### PR TITLE
Rolled back dependancy version of Paperclip to support Paperclip 3.

### DIFF
--- a/paperclip-dimension-validator.gemspec
+++ b/paperclip-dimension-validator.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'paperclip',    '>= 4.0.0'
+  spec.add_dependency 'paperclip',    '>= 3.0.0'
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
I've been wanting to upgrade to Paperclip 4 for a long while, however all the security changes they've made have caused a lot of issues with file-type detection which are effecting a bunch of people.

I've rolled back to the dependancy in the gemspec so I can use the validatior with my 3.x versions of Paperclip.
